### PR TITLE
Update Docker argument names

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 # Set default values for build arguments
-ARG DOCKERFILE_VERSION=1.2.0
-ARG NETCORE_VERSION=3.1-alpine3.12
+ARG DEFRA_VERSION=1.2.0
+ARG BASE_VERSION=3.1-alpine3.12
 
 # Extend Alpine variant of ASP.net base image for small image size
-FROM mcr.microsoft.com/dotnet/core/aspnet:$NETCORE_VERSION AS production
+FROM mcr.microsoft.com/dotnet/core/aspnet:$BASE_VERSION AS production
 
-ARG DOCKERFILE_VERSION
-ARG NETCORE_VERSION
+ARG DEFRA_VERSION
+ARG BASE_VERSION
 
 # Default the runtime image to run as production
 ENV ASPNETCORE_ENVIRONMENT=production
@@ -25,21 +25,21 @@ USER dotnet
 WORKDIR /home/dotnet
 
 # Label images to aid searching
-LABEL uk.gov.defra.dotnetcore.dotnet-version=$NETCORE_VERSION \
-      uk.gov.defra.dotnetcore.version=$DOCKERFILE_VERSION \
+LABEL uk.gov.defra.dotnetcore.dotnet-version=$BASE_VERSION \
+      uk.gov.defra.dotnetcore.version=$DEFRA_VERSION \
       uk.gov.defra.dotnetcore.repository=defradigital/dotnetcore
 
 # Extend Alpine variant of .Net Core SDK base image for small image size
-FROM mcr.microsoft.com/dotnet/core/sdk:$NETCORE_VERSION AS development
+FROM mcr.microsoft.com/dotnet/core/sdk:$BASE_VERSION AS development
 
-ARG DOCKERFILE_VERSION
-ARG NETCORE_VERSION
+ARG DEFRA_VERSION
+ARG BASE_VERSION
 
 # Default the SDK image to run as development
 ENV ASPNETCORE_ENVIRONMENT=development
 
-LABEL uk.gov.defra.dotnetcore.dotnet-version=$NETCORE_VERSION \
-      uk.gov.defra.dotnetcore.version=$DOCKERFILE_VERSION \
+LABEL uk.gov.defra.dotnetcore.dotnet-version=$BASE_VERSION \
+      uk.gov.defra.dotnetcore.version=$DEFRA_VERSION \
       uk.gov.defra.dotnetcore.repository=defradigital/dotnetcore-development
 
 # Install dev tools, such as remote debugger and its dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Set default values for build arguments
-ARG DEFRA_VERSION=1.2.0
+ARG DEFRA_VERSION=1.2.1
 ARG BASE_VERSION=3.1-alpine3.12
 
 # Extend Alpine variant of ASP.net base image for small image size

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('defra-docker-jenkins@v-1') _
+@Library('defra-docker-jenkins@v-2') _
 
 import uk.gov.defra.ImageMap
 
@@ -9,4 +9,4 @@ ImageMap[] imageMaps = [
 buildParentImage imageName: 'dotnetcore',
   tagName: 'dotnet',
   imageMaps: imageMaps,
-  version: '1.2.0'
+  version: '1.2.1'

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ docker build --no-cache --target <target> .
 ```
 (where <target> is either `development` or `production`).
 
-This will build an image using the default `NETCORE_VERSION` as set in the [Dockerfile](Dockerfile).
+This will build an image using the default `BASE_VERSION` as set in the [Dockerfile](Dockerfile).
 
 ## Internal CA certificates
 

--- a/example/Dockerfile
+++ b/example/Dockerfile
@@ -2,7 +2,7 @@
 # and defra-dotnetcore-development tagged with a version.
 
 # Allow parent image version to be set at build time
-ARG PARENT_VERSION=1.0.0
+ARG PARENT_VERSION=1.2.0-dotnet3.1
 
 # Development stage, used the build the app and provide testing tools
 FROM defra-dotnetcore-development:$PARENT_VERSION AS development


### PR DESCRIPTION
he defra-docker-jenkins library uses a language agnostic version argument
BASE_VERSION when building an image. VERSION has been replaced with DEFRA_VERSION.

NETCORE_VERSION and DOCKERFILE_VERSION in this repo should be changed to reflect the new names in v2 of the library.