### PR TITLE
Patch vulnerability CVE-2020-28196

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ARG BASE_VERSION
 ENV ASPNETCORE_ENVIRONMENT=production
 
 # Install Internal CA certificate
-RUN apk update && apk add --no-cache ca-certificates && apk add --no-cache krb5-libs~1.18.3 && rm -rf /var/cache/apk/*
+RUN apk update && apk add --no-cache ca-certificates && apk add --no-cache krb5-libs~=1.18.3 && rm -rf /var/cache/apk/*
 COPY certificates/internal-ca.crt /usr/local/share/ca-certificates/internal-ca.crt
 RUN chmod 644 /usr/local/share/ca-certificates/internal-ca.crt && update-ca-certificates
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ARG BASE_VERSION
 ENV ASPNETCORE_ENVIRONMENT=production
 
 # Install Internal CA certificate
-RUN apk update && apk add --no-cache ca-certificates && apk add --no-cache krb5-libs~=1.18.3 && rm -rf /var/cache/apk/*
+RUN apk update && apk add --no-cache ca-certificates && apk add --no-cache 'krb5-libs>1.18.3' && rm -rf /var/cache/apk/*
 COPY certificates/internal-ca.crt /usr/local/share/ca-certificates/internal-ca.crt
 RUN chmod 644 /usr/local/share/ca-certificates/internal-ca.crt && update-ca-certificates
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Set default values for build arguments
-ARG DEFRA_VERSION=1.2.1
+ARG DEFRA_VERSION=1.2.2
 ARG BASE_VERSION=3.1-alpine3.12
 
 # Extend Alpine variant of ASP.net base image for small image size
@@ -12,7 +12,7 @@ ARG BASE_VERSION
 ENV ASPNETCORE_ENVIRONMENT=production
 
 # Install Internal CA certificate
-RUN apk update && apk add --no-cache ca-certificates && rm -rf /var/cache/apk/*
+RUN apk update && apk add --no-cache ca-certificates && rm -rf /var/cache/apk/* && apk add krb5-libs~1.18.3
 COPY certificates/internal-ca.crt /usr/local/share/ca-certificates/internal-ca.crt
 RUN chmod 644 /usr/local/share/ca-certificates/internal-ca.crt && update-ca-certificates
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ARG BASE_VERSION
 ENV ASPNETCORE_ENVIRONMENT=production
 
 # Install Internal CA certificate
-RUN apk update && apk add --no-cache ca-certificates && rm -rf /var/cache/apk/* && apk add krb5-libs~1.18.3
+RUN apk update && apk add --no-cache ca-certificates && apk add --no-cache krb5-libs~1.18.3 && rm -rf /var/cache/apk/*
 COPY certificates/internal-ca.crt /usr/local/share/ca-certificates/internal-ca.crt
 RUN chmod 644 /usr/local/share/ca-certificates/internal-ca.crt && update-ca-certificates
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,4 +9,4 @@ ImageMap[] imageMaps = [
 buildParentImage imageName: 'dotnetcore',
   tagName: 'dotnet',
   imageMaps: imageMaps,
-  version: '1.2.1'
+  version: '1.2.2'


### PR DESCRIPTION
A vulnerability has been identified http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-28196

krb5-libs has been updated to 1.18.3 or later to fix the issue.

The actual supported version of krb5-lib in Alpine is `1.18.3-r0` as seen here 
https://pkgs.alpinelinux.org/packages?name=krb5-libs&branch=v3.12

Due to the versioning system of apt, `krb5-libs>1.18.2` or `krb5-libs>1.18.3` do not match `1.18.3-r0` so `krb5-libs~1.18.3` has been used instead. 

This will match 1.18.3 when released, but not any other patched versions. 