### PR TITLE
bump version in jenkins file

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,4 +9,4 @@ ImageMap[] imageMaps = [
 buildParentImage imageName: 'dotnetcore',
   tagName: 'dotnet',
   imageMaps: imageMaps,
-  version: '1.2.2'
+  version: '1.2.3'


### PR DESCRIPTION
Bring Jenkins file version in line with the scan.env settings.

The Jenkins file will be removed in future release when the build and publish in performed in a GitHub action.
